### PR TITLE
logos: updated VK and Telegram logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 <div id="badges" align="center">
     <a href="https://t.me/tehnomaniak07" target="_blank">
-      <img src="https://cdn-icons-png.flaticon.com/512/2111/2111646.png" width="40" height="40" alt="telegram group" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/Telegram_2019_Logo.svg/512px-Telegram_2019_Logo.svg.png" width="40" height="40" alt="telegram group" />
     </a>
     <a href="https://www.youtube.com/channel/UCbORpXVw1JNc0JYFSUqLWXA" target="_blank">
       <img src="https://cdn-icons-png.flaticon.com/512/3670/3670147.png" width="40" height="40" alt="Youtube"/>
     </a>
     <a href="https://vk.com/f1ll_zzz" target="_blank">
-      <img src="https://cdn-icons-png.flaticon.com/512/145/145813.png" width="40" height="40" alt="VK Badge"/>
+      <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/VK_Compact_Logo_%282021-present%29.svg/240px-VK_Compact_Logo_%282021-present%29.svg.png" width="40" height="40" alt="VK Badge"/>
     </a>
     <a href="https://zen.yandex.ru/id/603e522b3c020230bb223e5e" target="_blank">
       <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Yandex_Zen_logo_icon.svg/1024px-Yandex_Zen_logo_icon.svg.png" width="40" height="40" alt="Zen Badge"/>


### PR DESCRIPTION
обновил логотипы на новые в соответствии с брендбуками.

до/после:

![1](https://github.com/user-attachments/assets/cd6b0281-3542-4e0e-a7c5-7249861ceba7)
![2](https://github.com/user-attachments/assets/90844b25-9da3-4a07-946c-72140bfcbd52)
