### PR TITLE
Add ResumeAI to resume/ATS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
  - [Поисковик онлайн-репозиториев](https://libraries.io/)
  - [Cервис для автоматической проверки качества кода](https://www.codefactor.io/)
  - [Cервис для облегчения создания резюме](https://resume.io/)
+ - [ResumeAI — AI-резюме и бесплатный ATS-чекер](https://withresumeai.com/) (State of ATS 2026: 738/704, Workday 37.9%)
  - [Коллекция инструментов для дизайна](https://undesign.learn.uno/)
 
  ## Подготовка к собеседованию


### PR DESCRIPTION
Add ResumeAI (https://withresumeai.com/) next to similar resume/ATS tools.

- Free ATS checks: 3/day anonymous, 10/day with a free account
- State of ATS 2026: 738 employers, 704 portal-verified; Workday 37.9%
- Live candidate leaderboard: paid placement/visibility only (not pay-for-score)

Happy to adjust wording/placement if preferred.